### PR TITLE
clear cin buffer for processCommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,4 @@ FodyWeavers.xsd
 *.sln.iml
 
 coverage/
+*.txt

--- a/AppTest/test.cpp
+++ b/AppTest/test.cpp
@@ -55,6 +55,7 @@ TEST_F(TestShellTestFixture, TestWrite) {
 
 	shell->write(0, "0xDEADCODE");
 }
+
 TEST_F(TestShellTestFixture, TestRead) {
 
 	EXPECT_CALL(mock_ssd, read(0))
@@ -68,7 +69,7 @@ TEST_F(TestShellTestFixture, TestRead) {
 	EXPECT_EQ(output, "0x01234567\n");
 }
 
-TEST_F(TestShellTestFixture, TESTFullRead) {
+TEST_F(TestShellTestFixture, TestFullRead) {
 	string testvalue = "0x01234567";
 	EXPECT_CALL(mock_ssd, read(AllOf(Ge(0), Le(99))))
 		.Times(100)
@@ -79,10 +80,9 @@ TEST_F(TestShellTestFixture, TESTFullRead) {
 	string output = testing::internal::GetCapturedStdout();
 
 	EXPECT_EQ(getValidCount(output, testvalue), 100);
-
 }
 
-TEST_F(TestShellTestFixture, TESTFullWrite) {
+TEST_F(TestShellTestFixture, TestFullWrite) {
 	string testvalue = "0x01234567";
 	EXPECT_CALL(mock_ssd, write(AllOf(Ge(0), Le(99)), testvalue))
 		.Times(100);
@@ -139,6 +139,7 @@ TEST_F(TestShellTestFixture, TestGetValue) {
 
 	EXPECT_THROW(shell->getValue(), InvalidInputException);
 }
+
 TEST_F(TestShellTestFixture, TestGetValueNormal) {
 	setMockInput("0xABCDABCD");
 
@@ -180,6 +181,7 @@ TEST_F(SsdDriverTestFixture, DummySsdRead) {
 	string output = testing::internal::GetCapturedStdout();
 	EXPECT_EQ(output, "0x12345678\n");
 }
+
 TEST_F(SsdDriverTestFixture, DummySsdWrite) {
 	shell->write(0x1, "0x87654321");
 

--- a/TestShell/TestShell.cpp
+++ b/TestShell/TestShell.cpp
@@ -22,6 +22,7 @@ public:
 			}
 			catch (InvalidInputException e) {
 				cout << e.what() << endl;
+				while (std::cin.get() != '\n');
 				help();
 			}
 			catch (ExitException e) {


### PR DESCRIPTION
## 개요
- TestShell에서 command lba value 다중으로 입력 오류 있을 경우 exception message 여러번 출력되는 이슈 수정

Resolves: #2 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
