### PR TITLE
#67 FIX get correct iterator when add/find item

### DIFF
--- a/SSD/CommandQueue.cpp
+++ b/SSD/CommandQueue.cpp
@@ -43,11 +43,12 @@ public:
 		if (item.cmdName == "E") {
 			int itemFirstLba = stoi(item.parameter1);
 			int itemLastLba = itemFirstLba + stoi(item.parameter2) - 1;
-			for (auto iter = items.begin(); iter < items.end();) {
+			for (auto iter = items.begin(); iter != items.end();) {
 				if (iter->cmdName == "W") {
 					int writeLba = stoi(iter->parameter1);
 					if (writeLba >= itemFirstLba && writeLba <= itemLastLba) {
 						iter = items.erase(iter);
+						continue;
 					}
 				}
 				else if (iter->cmdName == "E") {
@@ -55,6 +56,7 @@ public:
 					int eraseLastLba = eraseFirstLba + stoi(iter->parameter2) - 1;
 					if (eraseFirstLba >= itemFirstLba && eraseLastLba <= itemLastLba) {
 						iter = items.erase(iter);
+						continue;
 					}
 				}
 				iter++;
@@ -63,11 +65,12 @@ public:
 		else if (item.cmdName == "W") {
 			int itemLba = stoi(item.parameter1);
 
-			for (auto iter = items.begin(); iter < items.end();) {
+			for (auto iter = items.begin(); iter != items.end();) {
 				if (iter->cmdName == "W") {
 					int writeLba = stoi(iter->parameter1);
 					if (writeLba == itemLba) {
 						iter = items.erase(iter);
+						continue;
 					}
 				}
 				iter++;
@@ -83,7 +86,7 @@ public:
 		vector<CommandQueueItem> items = getItems();
 		reverse(items.begin(), items.end());
 
-		for (auto iter = items.begin(); iter < items.end(); iter++) {
+		for (auto iter = items.begin(); iter != items.end(); iter++) {
 			if (iter->cmdName == "W" && stoi(iter->parameter1) == lba) {
 				return iter->parameter2;
 			}
@@ -116,7 +119,7 @@ public:
 	}
 
 	void setItems(vector<CommandQueueItem> items) {
-		for (auto iter = items.begin(); iter < items.end(); iter++) {
+		for (auto iter = items.begin(); iter != items.end(); iter++) {
 			buffer[distance(items.begin(), iter)] = 
 				iter->cmdName + " " + iter->parameter1 + " " + iter->parameter2;
 		}


### PR DESCRIPTION
## 개요
1. buffer에 command를 add/find 할 때, 올바른 iterator를 호출하도록 수정
2. fast-write관련 test case 추가

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
